### PR TITLE
Proposal to add #toEqualAsArrays method in Koan.st to properly test arrays against OrderedCollection and SortedCollection

### DIFF
--- a/src/koans/TestOrderedCollection.st
+++ b/src/koans/TestOrderedCollection.st
@@ -20,7 +20,7 @@ Koan subclass: TestOrderedCollection [
 
     orderedCollection := OrderedCollection with: $a with: $b with: $c with: $d with: $e.
 
-    self expect: fillMeIn toEqual: (orderedCollection asArray).
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
     self expect: [ OrderedCollection with: 'a' with: 'b' with: 'c' with: 'd' with: 'e' with: 'f' ] toRaise: fillMeIn.
 
     "OrderedCollection responds to most messages that Array responds to."
@@ -31,7 +31,7 @@ Koan subclass: TestOrderedCollection [
 
     orderedCollection := OrderedCollection new addAll: #(5 6 7); yourself.
 
-    self expect: fillMeIn toEqual: orderedCollection.
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
   ]
 
   testAddElements [
@@ -40,19 +40,19 @@ Koan subclass: TestOrderedCollection [
     orderedCollection := OrderedCollection with: 1.
     orderedCollection addFirst: 2.
 
-    self expect: fillMeIn toEqual: orderedCollection.
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
 
     orderedCollection addLast: 3.
 
-    self expect: fillMeIn toEqual: orderedCollection.
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
 
     orderedCollection add: 4 afterIndex: 2.
 
-    self expect: fillMeIn toEqual: orderedCollection.
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
 
     orderedCollection add: 5 beforeIndex: 2.
 
-    self expect: fillMeIn toEqual: orderedCollection.
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
   ]
 
   testRemoveElements [
@@ -61,15 +61,15 @@ Koan subclass: TestOrderedCollection [
     orderedCollection := OrderedCollection with: 1 with: 2 with: 3 with: 4.
     orderedCollection removeFirst.
 
-    self expect: fillMeIn toEqual: orderedCollection.
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
 
     orderedCollection removeLast.
 
-    self expect: fillMeIn toEqual: orderedCollection.
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
 
     orderedCollection removeAtIndex: 1.
 
-    self expect: fillMeIn toEqual: orderedCollection.
+    self expect: fillMeIn toEqualAsArrays: orderedCollection.
   ]
 
   testAccessingElements [

--- a/src/koans/TestSortedCollection.st
+++ b/src/koans/TestSortedCollection.st
@@ -25,7 +25,7 @@ Koan subclass: TestSortedCollection [
       add: 3;
       add: 4.
 
-    self expect: fillMeIn toEqual: sortedCollection.
+    self expect: fillMeIn toEqualAsArrays: sortedCollection.
   ]
 
   testComparingSortedCollections [

--- a/src/lib/Koan.st
+++ b/src/lib/Koan.st
@@ -29,6 +29,12 @@ Object subclass: Koan [
       ifFalse: [ self setTrackerToFalse: 'Expected value SHOULD equal actual value.' expected: expectedValue actual: actualValue ].
   ]
 
+  expect: expectedValue toEqualAsArrays: actualValue [
+    tracker status ifFalse: [^nil].
+    (expectedValue asArray = actualValue asArray)
+      ifFalse: [ self setTrackerToFalse: 'Expected array/collection SHOULD equal actual array/collection.' expected: expectedValue actual: actualValue ].
+  ]
+
   expect: expectedValue toNotEqual: actualValue [
     tracker status ifFalse: [^nil].
     (expectedValue = actualValue)


### PR DESCRIPTION
Hello, skim.

I saw you last commit you did yesterday. It really helped me but there are other koans with this kind of bug so I thought it would be great to fix them all at once.

So I added #toEqualAsArrays method in Koan.st and changed src/koans/TestOrderedCollection.st and src/koans/TestOrderedCollection.st respectively:

``` smalltalk
  expect: expectedValue toEqualAsArrays: actualValue [
    tracker status ifFalse: [^nil].
    (expectedValue asArray = actualValue asArray)
      ifFalse: [ self setTrackerToFalse: 'Expected array/collection SHOULD equal actual array/collection.' expected: expectedValue actual: actualValue ].
  ]
```

I tested it thoroughly so it works. What do think of it?

Thanks.
