### PR TITLE
probable typos in TestBasic fixed

### DIFF
--- a/src/koans/TestBasic.st
+++ b/src/koans/TestBasic.st
@@ -22,7 +22,7 @@ Koan subclass: TestBasic [
 
     self expect: fillMeIn toEqual: (variableA = variableB).
 
-    "#== is a message that checks if identity is equal.  More about messages in the TestMessage koan."
+    "#= is a message that checks if identity is equal.  More about messages in the TestMessage koan."
   ]
 
   testMultipleStatementsInASingleLine [
@@ -39,7 +39,7 @@ Koan subclass: TestBasic [
   testInequality [
     self expect: fillMeIn toEqual: ('hello' ~= 'world').
 
-    "#~~ is a message that checks if identity is not equal.  More about messages in the TestMessage koan."
+    "#~= is a message that checks if identity is not equal.  More about messages in the TestMessage koan."
   ]
 
   testLogicalOr [


### PR DESCRIPTION
I stumbled across some small inconsistencies of comments with code as going through the first "koans".