### PR TITLE
Add a Makefile to allow running in Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+run:
+	docker run --rm -i -t -v $(CURDIR):/source nacyot/smalltalk-gnu:apt script/run

--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,16 @@ sudo make install
 
 Test by running `gst` and interact with the REPL.
 
+### Using Docker
+
+Make sure you have Docker installed.
+
+Use the Makefile to run this application - in the root directory of the project, type:
+
+`make run`
+
+This will run `script/run`, using GNU Smalltalk.
+
 ### Running koans
 
 In the root directory of the project, type:


### PR DESCRIPTION
When running workshops, it is easier to get people started by leveraging Docker